### PR TITLE
Add high-order component.

### DIFF
--- a/lib/resize.js
+++ b/lib/resize.js
@@ -4,7 +4,7 @@
  */
 var React = require('react')
 var omit = require('lodash.omit')
-var merge = require('merge')
+var merge = require('lodash.merge')
 
 function resize(Component) {
   return React.createClass({

--- a/lib/resize.js
+++ b/lib/resize.js
@@ -1,0 +1,33 @@
+/**
+ * resize
+ * High-order component for WindowResizeListener
+ */
+var React = require('react')
+var omit = require('lodash.omit')
+var merge = require('merge')
+
+function resize(Component) {
+  return React.createClass({
+    getInitialState: function() {
+      windowHeight: 0,
+      windowWidth: 0
+    },
+
+    render: function render() {
+      var children = this.props.children;
+      var props = omit(this.props, ['children']);
+
+      return (
+        <WindowResizeListener onResize={this.onResize}>
+          {React.cloneElement(children, merge({}, props, this.state))}
+        </WindowResizeListener>
+      )
+    },
+
+    onResize: function(size) {
+      this.setState(size)
+    }
+  })
+}
+
+exports.default = exports.resize = resize;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "zuul": "^3.7.1"
   },
   "dependencies": {
-    "lodash.debounce": "^3.1.1"
+    "lodash.debounce": "^3.1.1",
+    "lodash.merge": "^4.1.0",
+    "lodash.omit": "^4.0.2"
   },
   "peerDependencies": {
     "react": "^0.14.0"


### PR DESCRIPTION
## What
- Adds a resize HOC as discussed in #1 
- This adds a additional dependencies on `omit` and `merge`.

So far, I can't write any tests because:
- I think the API I just wrote sucks (but I think it matches the original API).
- The tests doesn't seem to be originally working:

``` bash
Error: TypeError: 'undefined' is not a function (evaluating 'RegExp.prototype.test.bind(/^(data|aria)-[a-z_][a-z\d_.\-]*$/)')
```
## Usage

``` es6
import resize 'react-window-resize-listener/resize'; // lmao

@resize
class C extends Component {
  render() {
    console.log(this.props); // { windowWidth, windowHeight }
  }
}
```

I think we should put it in _a_ property so we don't pollute the props, e.g., `this.props.window.width`.
# 

No pressure! Thanks for your work ;). Feedback is welcome!
