### PR TITLE
add support for React 16

### DIFF
--- a/lib/WindowResizeListener.js
+++ b/lib/WindowResizeListener.js
@@ -3,9 +3,11 @@
  * React component for listening to window resize events
  */
 var React = require('react')
+var PropTypes = require('prop-types')
+var createReactClass = require('create-react-class')
 var debounce = require('lodash.debounce')
 
-var WindowResizeListener = React.createClass({
+var WindowResizeListener = createReactClass({
   displayName: 'WindowResizeListener',
 
   propTypes: {
@@ -14,7 +16,7 @@ var WindowResizeListener = React.createClass({
      * type WindowSize = { windowWidth: number, windowHeight: number }
      * type onResize = (windowSize: WindowSize) => void
      */
-    onResize: React.PropTypes.func.isRequired
+    onResize: PropTypes.func.isRequired
   },
 
   statics: {

--- a/package.json
+++ b/package.json
@@ -29,16 +29,18 @@
   "homepage": "https://github.com/cesarandreu/react-window-resize-listener#readme",
   "devDependencies": {
     "phantomjs": "^1.9.18",
-    "react": "^0.14.0 || ^15.0.0",
-    "react-dom": "^0.14.0 || ^15.0.0",
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0 || ^16.0.0",
     "standard": "^5.3.1",
     "tape": "^4.2.2",
     "zuul": "^3.7.1"
   },
   "dependencies": {
-    "lodash.debounce": "^3.1.1"
+    "create-react-class": "^15.6.3",
+    "lodash.debounce": "^3.1.1",
+    "prop-types": "^15.6.2"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0 || ^16.0.0"
   }
 }


### PR DESCRIPTION
Closes #8 

`PropTypes` and `createClass()` are no longer shipped with React.